### PR TITLE
fix(UI): resolve Copy → View bug causing TypeError

### DIFF
--- a/wordpress/wp-content/plugins/minisite-manager/src/Application/Controllers/Front/SitesController.php
+++ b/wordpress/wp-content/plugins/minisite-manager/src/Application/Controllers/Front/SitesController.php
@@ -368,17 +368,19 @@ final class SitesController
         
         // If showing a specific version, also update the profile fields from version data
         if ($version) {
-            $minisite->title = $version->title;
-            $minisite->name = $version->name;
-            $minisite->city = $version->city;
-            $minisite->region = $version->region;
-            $minisite->countryCode = $version->countryCode;
-            $minisite->postalCode = $version->postalCode;
-            $minisite->siteTemplate = $version->siteTemplate;
-            $minisite->palette = $version->palette;
-            $minisite->industry = $version->industry;
-            $minisite->defaultLocale = $version->defaultLocale;
-            $minisite->searchTerms = $version->searchTerms;
+            // Use version data if available, otherwise fall back to existing minisite data
+            // This prevents null assignment errors when version data is incomplete
+            $minisite->title = $version->title ?? $minisite->title;
+            $minisite->name = $version->name ?? $minisite->name;
+            $minisite->city = $version->city ?? $minisite->city;
+            $minisite->region = $version->region ?? $minisite->region;
+            $minisite->countryCode = $version->countryCode ?? $minisite->countryCode;
+            $minisite->postalCode = $version->postalCode ?? $minisite->postalCode;
+            $minisite->siteTemplate = $version->siteTemplate ?? $minisite->siteTemplate;
+            $minisite->palette = $version->palette ?? $minisite->palette;
+            $minisite->industry = $version->industry ?? $minisite->industry;
+            $minisite->defaultLocale = $version->defaultLocale ?? $minisite->defaultLocale;
+            $minisite->searchTerms = $version->searchTerms ?? $minisite->searchTerms;
         }
 
         // Use the existing TimberRenderer to render the profile

--- a/wordpress/wp-content/plugins/minisite-manager/src/Application/Controllers/Front/VersionController.php
+++ b/wordpress/wp-content/plugins/minisite-manager/src/Application/Controllers/Front/VersionController.php
@@ -382,7 +382,23 @@ class VersionController
             createdAt: null,
             publishedAt: null,
             sourceVersionId: $sourceVersionId,
-            siteJson: $sourceVersion->siteJson
+            siteJson: $sourceVersion->siteJson,
+            // Copy all profile fields from source version to ensure preview works correctly
+            slugs: $sourceVersion->slugs,
+            title: $sourceVersion->title,
+            name: $sourceVersion->name,
+            city: $sourceVersion->city,
+            region: $sourceVersion->region,
+            countryCode: $sourceVersion->countryCode,
+            postalCode: $sourceVersion->postalCode,
+            geo: $sourceVersion->geo,
+            siteTemplate: $sourceVersion->siteTemplate,
+            palette: $sourceVersion->palette,
+            industry: $sourceVersion->industry,
+            defaultLocale: $sourceVersion->defaultLocale,
+            schemaVersion: $sourceVersion->schemaVersion,
+            siteVersion: $sourceVersion->siteVersion,
+            searchTerms: $sourceVersion->searchTerms
         );
 
         return $this->versionRepository->save($rollbackVersion);


### PR DESCRIPTION
- Fix null assignment error in preview when version data is incomplete
- Add fallback values in SitesController preview logic to prevent TypeError
- Fix createRollbackVersion to copy all profile fields from source version
- Ensures copied versions have complete data for preview functionality

Resolves: Copy → View workflow now works correctly without internal errors