### PR TITLE
Implement application folder tests

### DIFF
--- a/wordpress/wp-content/plugins/minisite-manager/tests/Integration/Application/Http/RewriteRegistrarIntegrationTest.php
+++ b/wordpress/wp-content/plugins/minisite-manager/tests/Integration/Application/Http/RewriteRegistrarIntegrationTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Application\Http;
+
+use Minisite\Application\Http\RewriteRegistrar;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RewriteRegistrar::class)]
+#[Group('integration')]
+final class RewriteRegistrarIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resetRewriteGlobals();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetRewriteGlobals();
+        parent::tearDown();
+    }
+
+    public function test_register_adds_rewrite_rules_to_wordpress_system(): void
+    {
+        (new RewriteRegistrar())->register();
+
+        $patterns = array(
+            '^b/([^/]+)/([^/]+)/?$',
+            '^account/(login|register|dashboard|logout|forgot|sites)/?$',
+            '^account/sites/new/?$',
+            '^account/sites/publish/?$',
+            '^account/sites/([a-f0-9]{24,32})/edit/([0-9]+|latest)/?$',
+            '^account/sites/([a-f0-9]{24,32})/edit/?$',
+            '^account/sites/([a-f0-9]{24,32})/preview/([0-9]+|current)/?$',
+            '^account/sites/([a-f0-9]{24,32})/versions/?$',
+            '^account/sites/([a-f0-9]{24,32})/publish/?$',
+            '^account/sites/([a-f0-9]{24,32})/?$',
+        );
+
+        foreach ($patterns as $pattern) {
+            $this->assertArrayHasKey(
+                $pattern,
+                $GLOBALS['wp_rewrite']->rules,
+                sprintf('WordPress rewrite rules should contain pattern "%s"', $pattern)
+            );
+        }
+    }
+
+    public function test_register_tracks_top_priority_for_all_rules(): void
+    {
+        (new RewriteRegistrar())->register();
+
+        foreach ($GLOBALS['_test_wp_rewrite_rules'] as $rule) {
+            $this->assertSame('top', $rule['after']);
+        }
+    }
+
+    public function test_register_creates_valid_redirect_targets(): void
+    {
+        (new RewriteRegistrar())->register();
+
+        foreach ($GLOBALS['_test_wp_rewrite_rules'] as $rule) {
+            $this->assertStringStartsWith('index.php?', $rule['redirect']);
+            $this->assertStringContainsString('minisite', $rule['redirect']);
+        }
+    }
+
+    private function resetRewriteGlobals(): void
+    {
+        $GLOBALS['_test_wp_rewrite_tags'] = array();
+        $GLOBALS['_test_wp_rewrite_rules'] = array();
+        $GLOBALS['wp_rewrite'] = new class () {
+            public array $rules = array();
+        };
+    }
+}

--- a/wordpress/wp-content/plugins/minisite-manager/tests/Integration/Application/Rendering/TimberRendererIntegrationTest.php
+++ b/wordpress/wp-content/plugins/minisite-manager/tests/Integration/Application/Rendering/TimberRendererIntegrationTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Application\Rendering;
+
+use Minisite\Application\Rendering\TimberRenderer;
+use Minisite\Features\MinisiteManagement\Domain\Entities\Minisite;
+use Minisite\Features\MinisiteViewer\ViewModels\MinisiteViewModel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TimberRenderer::class)]
+#[Group('integration')]
+final class TimberRendererIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        \Timber\Timber::$locations = array();
+        \Timber\Timber::$renderCalls = array();
+        unset($GLOBALS['_test_override_application_class_exists'], $GLOBALS['_test_renderer_headers']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['_test_override_application_class_exists'], $GLOBALS['_test_renderer_headers']);
+        \Timber\Timber::$locations = array();
+        \Timber\Timber::$renderCalls = array();
+        parent::tearDown();
+    }
+
+    public function test_render_with_timber_renders_template_output(): void
+    {
+        $renderer = new TimberRenderer();
+        $viewModel = $this->createViewModel('Integration Title', 'Integration Name');
+
+        $output = $this->captureOutput(static function () use ($renderer, $viewModel): void {
+            $renderer->render($viewModel);
+        });
+
+        $this->assertStringContainsString('<div class="auth-page">', $output);
+        $this->assertNotEmpty(\Timber\Timber::$renderCalls);
+    }
+
+    public function test_render_registers_plugin_template_location(): void
+    {
+        $renderer = new TimberRenderer('v2035');
+        $viewModel = $this->createViewModel();
+
+        $this->captureOutput(static function () use ($renderer, $viewModel): void {
+            $renderer->render($viewModel);
+        });
+
+        $expectedPath = trailingslashit(MINISITE_PLUGIN_DIR) . 'templates/timber';
+        $this->assertContains($expectedPath, \Timber\Timber::$locations);
+    }
+
+    public function test_render_without_timber_falls_back_to_html_output(): void
+    {
+        $renderer = new TimberRenderer();
+        $viewModel = $this->createViewModel('Fallback Integration Title', 'Fallback Integration Name');
+
+        $GLOBALS['_test_override_application_class_exists'] = static function (string $class): bool {
+            if ($class === 'Timber\\Timber') {
+                return false;
+            }
+
+            return \class_exists($class);
+        };
+
+        $output = $this->captureOutput(static function () use ($renderer, $viewModel): void {
+            $renderer->render($viewModel);
+        });
+
+        $this->assertStringStartsWith('<!doctype html>', trim($output));
+        $this->assertStringContainsString('Fallback Integration Title', $output);
+        $this->assertStringContainsString('Fallback Integration Name', $output);
+        $this->assertEmpty(\Timber\Timber::$renderCalls);
+    }
+
+    private function createViewModel(string $title = 'Test Title', string $name = 'Test Name'): MinisiteViewModel
+    {
+        $minisite = new Minisite(
+            id: 'abcdefabcdefabcdefabcdef',
+            slug: 'integration-slug',
+            slugs: null,
+            title: $title,
+            name: $name,
+            city: 'Austin',
+            region: 'TX',
+            countryCode: 'US',
+            postalCode: '73301',
+            geo: null,
+            siteTemplate: 'v2025',
+            palette: 'blue',
+            industry: 'services',
+            defaultLocale: 'en-US',
+            schemaVersion: 1,
+            siteVersion: 1,
+            siteJson: array('blocks' => array()),
+            searchTerms: null,
+            status: 'published',
+            publishStatus: 'published'
+        );
+
+        return new MinisiteViewModel($minisite);
+    }
+
+    private function captureOutput(callable $callback): string
+    {
+        ob_start();
+        try {
+            $callback();
+        } finally {
+            $output = ob_get_clean();
+        }
+
+        return $output;
+    }
+}

--- a/wordpress/wp-content/plugins/minisite-manager/tests/Support/ApplicationRenderingTestStubs.php
+++ b/wordpress/wp-content/plugins/minisite-manager/tests/Support/ApplicationRenderingTestStubs.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minisite\Application\Rendering {
+    if (! function_exists(__NAMESPACE__ . '\class_exists')) {
+        /**
+         * Allow tests to override class_exists checks within the Application\Rendering namespace.
+         */
+        function class_exists(string $class, bool $autoload = true): bool
+        {
+            if (isset($GLOBALS['_test_override_application_class_exists'])) {
+                $override = $GLOBALS['_test_override_application_class_exists'];
+                if (is_callable($override)) {
+                    return (bool) $override($class, $autoload);
+                }
+
+                return (bool) $override;
+            }
+
+            return \class_exists($class, $autoload);
+        }
+    }
+
+    if (! function_exists(__NAMESPACE__ . '\header')) {
+        /**
+         * Capture header() calls issued by TimberRenderer for assertions.
+         */
+        function header(string $header, bool $replace = true, int $http_response_code = 0): void
+        {
+            if (! isset($GLOBALS['_test_renderer_headers'])) {
+                $GLOBALS['_test_renderer_headers'] = array();
+            }
+
+            $GLOBALS['_test_renderer_headers'][] = array(
+                'header' => $header,
+                'replace' => $replace,
+                'response_code' => $http_response_code,
+            );
+
+            if (! empty($GLOBALS['_test_renderer_forward_headers'])) {
+                \header($header, $replace, $http_response_code);
+            }
+        }
+    }
+}

--- a/wordpress/wp-content/plugins/minisite-manager/tests/Support/WordPressFunctions.php
+++ b/wordpress/wp-content/plugins/minisite-manager/tests/Support/WordPressFunctions.php
@@ -86,14 +86,39 @@ if (! function_exists('add_submenu_page')) {
 if (! function_exists('add_rewrite_tag')) {
     function add_rewrite_tag($tag, $regex, $query = '')
     {
-        // Mock - do nothing in tests
+        if (! isset($GLOBALS['_test_wp_rewrite_tags'])) {
+            $GLOBALS['_test_wp_rewrite_tags'] = array();
+        }
+
+        $GLOBALS['_test_wp_rewrite_tags'][$tag] = array(
+            'regex' => $regex,
+            'query' => $query,
+        );
     }
 }
 
 if (! function_exists('add_rewrite_rule')) {
     function add_rewrite_rule($regex, $redirect, $after = 'bottom')
     {
-        // Mock - do nothing in tests
+        if (! isset($GLOBALS['_test_wp_rewrite_rules'])) {
+            $GLOBALS['_test_wp_rewrite_rules'] = array();
+        }
+
+        $GLOBALS['_test_wp_rewrite_rules'][] = array(
+            'pattern' => $regex,
+            'redirect' => $redirect,
+            'after' => $after,
+        );
+
+        if (! isset($GLOBALS['wp_rewrite'])) {
+            $GLOBALS['wp_rewrite'] = new class () {
+                public array $rules = array();
+            };
+        } elseif (! isset($GLOBALS['wp_rewrite']->rules) || ! is_array($GLOBALS['wp_rewrite']->rules)) {
+            $GLOBALS['wp_rewrite']->rules = array();
+        }
+
+        $GLOBALS['wp_rewrite']->rules[$regex] = $redirect;
     }
 }
 

--- a/wordpress/wp-content/plugins/minisite-manager/tests/Unit/Application/Http/RewriteRegistrarTest.php
+++ b/wordpress/wp-content/plugins/minisite-manager/tests/Unit/Application/Http/RewriteRegistrarTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Application\Http;
+
+use Brain\Monkey\Functions;
+use Minisite\Application\Http\RewriteRegistrar;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RewriteRegistrar::class)]
+final class RewriteRegistrarTest extends TestCase
+{
+    /**
+     * @var array<string, array{regex: string, query: string}>
+     */
+    private array $registeredTags = array();
+
+    /**
+     * @var array<int, array{pattern: string, redirect: string, after: string}>
+     */
+    private array $registeredRules = array();
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        \Brain\Monkey\setUp();
+        $this->registeredTags = array();
+        $this->registeredRules = array();
+
+        Functions\when('add_rewrite_tag')->alias(function (string $tag, string $regex, string $query = ''): void {
+            $this->registeredTags[$tag] = array(
+                'regex' => $regex,
+                'query' => $query,
+            );
+        });
+
+        Functions\when('add_rewrite_rule')->alias(function (string $pattern, string $redirect, string $after = 'bottom'): void {
+            $this->registeredRules[] = array(
+                'pattern' => $pattern,
+                'redirect' => $redirect,
+                'after' => $after,
+            );
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        $this->registeredTags = array();
+        $this->registeredRules = array();
+        \Brain\Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_register_registers_expected_rewrite_tags(): void
+    {
+        (new RewriteRegistrar())->register();
+
+        $expected = array(
+            '%minisite%' => '([0-1])',
+            '%minisite_biz%' => '([^&]+)',
+            '%minisite_loc%' => '([^&]+)',
+            '%minisite_account%' => '([0-1])',
+            '%minisite_account_action%' => '([^&]+)',
+            '%minisite_id%' => '([a-f0-9]{24,32})',
+            '%minisite_version_id%' => '([0-9]+|current|latest)',
+        );
+
+        $this->assertCount(count($expected), $this->registeredTags);
+        foreach ($expected as $tag => $regex) {
+            $this->assertArrayHasKey($tag, $this->registeredTags);
+            $this->assertSame($regex, $this->registeredTags[$tag]['regex']);
+        }
+    }
+
+    #[DataProvider('rewriteRuleProvider')]
+    public function test_register_registers_expected_rewrite_rule(string $pattern, string $redirect): void
+    {
+        (new RewriteRegistrar())->register();
+
+        $rule = $this->findRule($pattern);
+        $this->assertNotNull($rule, sprintf('Expected rule for pattern "%s" to be registered', $pattern));
+        $this->assertSame($redirect, $rule['redirect']);
+        $this->assertSame('top', $rule['after']);
+    }
+
+    public function test_register_records_expected_number_of_rules(): void
+    {
+        (new RewriteRegistrar())->register();
+        $this->assertCount(10, $this->registeredRules);
+    }
+
+    public function test_register_sets_top_priority_for_all_rules(): void
+    {
+        (new RewriteRegistrar())->register();
+
+        foreach ($this->registeredRules as $rule) {
+            $this->assertSame('top', $rule['after'], sprintf('Rule "%s" should have top priority', $rule['pattern']));
+        }
+    }
+
+    public function test_register_preserves_existing_rules(): void
+    {
+        $legacyRule = array(
+            'pattern' => '^legacy/route/?$',
+            'redirect' => 'index.php?legacy=1',
+            'after' => 'bottom',
+        );
+        $this->registeredRules[] = $legacyRule;
+
+        (new RewriteRegistrar())->register();
+
+        $this->assertContains($legacyRule, $this->registeredRules);
+        $this->assertCount(11, $this->registeredRules);
+    }
+
+    public function test_register_creates_valid_regex_patterns(): void
+    {
+        (new RewriteRegistrar())->register();
+
+        foreach ($this->registeredRules as $rule) {
+            $pattern = $rule['pattern'];
+            $result = @preg_match('~' . $pattern . '~', '');
+            $this->assertNotFalse($result, sprintf('Pattern "%s" should be a valid regex', $pattern));
+        }
+    }
+
+    /**
+     * @return array<string, array{pattern: string, redirect: string}>
+     */
+    public static function rewriteRuleProvider(): array
+    {
+        return array(
+            'minisite profile route' => array(
+                'pattern' => '^b/([^/]+)/([^/]+)/?$',
+                'redirect' => 'index.php?minisite=1&minisite_biz=$matches[1]&minisite_loc=$matches[2]',
+            ),
+            'account action routes' => array(
+                'pattern' => '^account/(login|register|dashboard|logout|forgot|sites)/?$',
+                'redirect' => 'index.php?minisite_account=1&minisite_account_action=$matches[1]',
+            ),
+            'account sites new' => array(
+                'pattern' => '^account/sites/new/?$',
+                'redirect' => 'index.php?minisite_account=1&minisite_account_action=new',
+            ),
+            'account sites publish' => array(
+                'pattern' => '^account/sites/publish/?$',
+                'redirect' => 'index.php?minisite_account=1&minisite_account_action=publish',
+            ),
+            'account site edit with version' => array(
+                'pattern' => '^account/sites/([a-f0-9]{24,32})/edit/([0-9]+|latest)/?$',
+                'redirect' => 'index.php?minisite_account=1&minisite_account_action=edit&minisite_id=$matches[1]&minisite_version_id=$matches[2]',
+            ),
+            'account site edit default' => array(
+                'pattern' => '^account/sites/([a-f0-9]{24,32})/edit/?$',
+                'redirect' => 'index.php?minisite_account=1&minisite_account_action=edit&minisite_id=$matches[1]',
+            ),
+            'account site preview' => array(
+                'pattern' => '^account/sites/([a-f0-9]{24,32})/preview/([0-9]+|current)/?$',
+                'redirect' => 'index.php?minisite_account=1&minisite_account_action=preview&minisite_id=$matches[1]&minisite_version_id=$matches[2]',
+            ),
+            'account site versions' => array(
+                'pattern' => '^account/sites/([a-f0-9]{24,32})/versions/?$',
+                'redirect' => 'index.php?minisite_account=1&minisite_account_action=versions&minisite_id=$matches[1]',
+            ),
+            'account site publish with id' => array(
+                'pattern' => '^account/sites/([a-f0-9]{24,32})/publish/?$',
+                'redirect' => 'index.php?minisite_account=1&minisite_account_action=publish&minisite_id=$matches[1]',
+            ),
+            'account site default edit' => array(
+                'pattern' => '^account/sites/([a-f0-9]{24,32})/?$',
+                'redirect' => 'index.php?minisite_account=1&minisite_account_action=edit&minisite_id=$matches[1]',
+            ),
+        );
+    }
+
+    /**
+     * Find a registered rule by its pattern.
+     *
+     * @return array{pattern: string, redirect: string, after: string}|null
+     */
+    private function findRule(string $pattern): ?array
+    {
+        foreach ($this->registeredRules as $rule) {
+            if ($rule['pattern'] === $pattern) {
+                return $rule;
+            }
+        }
+
+        return null;
+    }
+}

--- a/wordpress/wp-content/plugins/minisite-manager/tests/Unit/Application/Rendering/TimberRendererTest.php
+++ b/wordpress/wp-content/plugins/minisite-manager/tests/Unit/Application/Rendering/TimberRendererTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Application\Rendering {
+
+    use Minisite\Application\Rendering\TimberRenderer;
+    use Minisite\Features\MinisiteManagement\Domain\Entities\Minisite;
+    use Minisite\Features\MinisiteViewer\ViewModels\MinisiteViewModel;
+    use PHPUnit\Framework\Attributes\CoversClass;
+    use PHPUnit\Framework\TestCase;
+
+    #[CoversClass(TimberRenderer::class)]
+    final class TimberRendererTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            parent::setUp();
+            \Timber\Timber::$locations = array();
+            \Timber\Timber::$renderCalls = array();
+            unset($GLOBALS['_test_override_application_class_exists'], $GLOBALS['_test_renderer_headers']);
+        }
+
+        protected function tearDown(): void
+        {
+            unset($GLOBALS['_test_override_application_class_exists'], $GLOBALS['_test_renderer_headers']);
+            \Timber\Timber::$locations = array();
+            \Timber\Timber::$renderCalls = array();
+            parent::tearDown();
+        }
+
+        public function test_constructor_sets_variant(): void
+        {
+            $renderer = new TimberRenderer('v2024');
+
+            $variantProperty = (new \ReflectionClass(TimberRenderer::class))->getProperty('variant');
+            $variantProperty->setAccessible(true);
+
+            $this->assertSame('v2024', $variantProperty->getValue($renderer));
+        }
+
+        public function test_constructor_uses_default_variant(): void
+        {
+            $renderer = new TimberRenderer();
+
+            $variantProperty = (new \ReflectionClass(TimberRenderer::class))->getProperty('variant');
+            $variantProperty->setAccessible(true);
+
+            $this->assertSame('v2025', $variantProperty->getValue($renderer));
+        }
+
+        public function test_render_with_timber_available_calls_render_and_registers_locations(): void
+        {
+            $renderer = new TimberRenderer();
+            $viewModel = $this->createViewModel();
+
+            $output = $this->captureOutput(static function () use ($renderer, $viewModel): void {
+                $renderer->render($viewModel);
+            });
+
+            $this->assertStringContainsString('<div class="auth-page">', $output);
+            $this->assertNotEmpty(\Timber\Timber::$renderCalls);
+
+            $renderCall = \Timber\Timber::$renderCalls[0];
+            $this->assertSame(array('v2025/minisite.twig'), $renderCall['templates']);
+            $this->assertSame($viewModel->toArray(), $renderCall['context']);
+
+            $expectedPath = trailingslashit(MINISITE_PLUGIN_DIR) . 'templates/timber';
+            $this->assertContains($expectedPath, \Timber\Timber::$locations);
+        }
+
+        public function test_render_uses_variant_in_template_path(): void
+        {
+            $renderer = new TimberRenderer('v2030');
+            $viewModel = $this->createViewModel();
+
+            $this->captureOutput(static function () use ($renderer, $viewModel): void {
+                $renderer->render($viewModel);
+            });
+
+            $renderCall = \Timber\Timber::$renderCalls[0];
+            $this->assertSame(array('v2030/minisite.twig'), $renderCall['templates']);
+        }
+
+        public function test_render_without_timber_calls_fallback_and_sets_header(): void
+        {
+            $renderer = new TimberRenderer();
+            $viewModel = $this->createViewModel('No Timber Title', 'No Timber Name');
+
+            $GLOBALS['_test_override_application_class_exists'] = static function (string $class): bool {
+                if ($class === 'Timber\\Timber') {
+                    return false;
+                }
+
+                return \class_exists($class);
+            };
+
+            $output = $this->captureOutput(static function () use ($renderer, $viewModel): void {
+                $renderer->render($viewModel);
+            });
+
+            $this->assertStringContainsString('<!doctype html>', $output);
+            $this->assertStringContainsString('No Timber Title', $output);
+            $this->assertStringContainsString('No Timber Name', $output);
+            $this->assertSame('Content-Type: text/html; charset=utf-8', $GLOBALS['_test_renderer_headers'][0]['header'] ?? null);
+            $this->assertEmpty(\Timber\Timber::$renderCalls, 'Timber::render should not be called when Timber is unavailable');
+        }
+
+        public function test_render_fallback_outputs_expected_html_structure(): void
+        {
+            $renderer = new TimberRenderer();
+            $viewModel = $this->createViewModel('Fallback Title', 'Fallback Name');
+
+            $method = (new \ReflectionClass(TimberRenderer::class))->getMethod('renderFallback');
+            $method->setAccessible(true);
+
+            $output = $this->captureOutput(static function () use ($method, $renderer, $viewModel): void {
+                $method->invoke($renderer, $viewModel);
+            });
+
+            $this->assertStringContainsString('<!doctype html>', $output);
+            $this->assertStringContainsString('<meta charset="utf-8">', $output);
+            $this->assertStringContainsString('<title>Fallback Title</title>', $output);
+            $this->assertStringContainsString('<h1>Fallback Name</h1>', $output);
+        }
+
+        public function test_render_fallback_escapes_html_entities(): void
+        {
+            $renderer = new TimberRenderer();
+            $viewModel = $this->createViewModel('<script>alert(1)</script>', '<b>unsafe</b>');
+
+            $method = (new \ReflectionClass(TimberRenderer::class))->getMethod('renderFallback');
+            $method->setAccessible(true);
+
+            $output = $this->captureOutput(static function () use ($method, $renderer, $viewModel): void {
+                $method->invoke($renderer, $viewModel);
+            });
+
+            $this->assertStringNotContainsString('<script>', $output);
+            $this->assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt;', $output);
+            $this->assertStringContainsString('&lt;b&gt;unsafe&lt;/b&gt;', $output);
+        }
+
+        public function test_render_fallback_handles_empty_minisite_data(): void
+        {
+            $renderer = new TimberRenderer();
+            $minisite = $this->createViewModel('', '')->getMinisite();
+            $minisite->title = '';
+            $minisite->name = '';
+
+            $method = (new \ReflectionClass(TimberRenderer::class))->getMethod('renderFallback');
+            $method->setAccessible(true);
+
+            $output = $this->captureOutput(static function () use ($method, $renderer, $minisite): void {
+                $viewModel = new MinisiteViewModel($minisite);
+                $method->invoke($renderer, $viewModel);
+            });
+
+            $this->assertStringContainsString('<title></title>', $output);
+            $this->assertStringContainsString('<h1></h1>', $output);
+        }
+
+        public function test_register_timber_locations_preserves_existing_and_removes_duplicates(): void
+        {
+            \Timber\Timber::$locations = array(
+                '/custom/location',
+                trailingslashit(MINISITE_PLUGIN_DIR) . 'templates/timber',
+            );
+
+            $renderer = new TimberRenderer();
+            $method = (new \ReflectionClass(TimberRenderer::class))->getMethod('registerTimberLocations');
+            $method->setAccessible(true);
+
+            $method->invoke($renderer);
+
+            $expected = trailingslashit(MINISITE_PLUGIN_DIR) . 'templates/timber';
+            $this->assertContains('/custom/location', \Timber\Timber::$locations);
+            $this->assertContains($expected, \Timber\Timber::$locations);
+
+            $keys = array_keys(\Timber\Timber::$locations);
+            $this->assertSame(range(0, count(\Timber\Timber::$locations) - 1), $keys, 'Locations array should be re-indexed');
+
+            $method->invoke($renderer);
+            $this->assertSame(\Timber\Timber::$locations[1], $expected, 'Plugin path should only appear once');
+        }
+
+        public function test_render_passes_view_model_context_to_timber(): void
+        {
+            $renderer = new TimberRenderer();
+            $viewModel = $this->createViewModel('Context Title', 'Context Name');
+
+            $this->captureOutput(static function () use ($renderer, $viewModel): void {
+                $renderer->render($viewModel);
+            });
+
+            $renderCall = \Timber\Timber::$renderCalls[0];
+            $context = $viewModel->toArray();
+
+            $this->assertSame($context['minisite']->title, $renderCall['context']['minisite']->title);
+            $this->assertSame($context['reviews'], $renderCall['context']['reviews']);
+            $this->assertTrue($renderCall['context']['minisite']->canEdit);
+            $this->assertTrue($renderCall['context']['minisite']->isBookmarked);
+        }
+
+        private function createViewModel(string $title = 'Test Title', string $name = 'Test Name'): MinisiteViewModel
+        {
+            $minisite = new Minisite(
+                id: '1234567890abcdef12345678',
+                slug: 'test-slug',
+                slugs: null,
+                title: $title,
+                name: $name,
+                city: 'Austin',
+                region: 'TX',
+                countryCode: 'US',
+                postalCode: '73301',
+                geo: null,
+                siteTemplate: 'v2025',
+                palette: 'blue',
+                industry: 'services',
+                defaultLocale: 'en-US',
+                schemaVersion: 1,
+                siteVersion: 1,
+                siteJson: array('blocks' => array()),
+                searchTerms: null,
+                status: 'published',
+                publishStatus: 'published'
+            );
+
+            return new MinisiteViewModel(
+                minisite: $minisite,
+                reviews: array(
+                    array('rating' => 5, 'comment' => 'Excellent!'),
+                ),
+                isBookmarked: true,
+                canEdit: true
+            );
+        }
+
+        /**
+         * Capture echo/print output for assertions.
+         */
+        private function captureOutput(callable $callback): string
+        {
+            ob_start();
+            try {
+                $callback();
+            } finally {
+                $output = ob_get_clean();
+            }
+
+            return $output;
+        }
+    }
+}

--- a/wordpress/wp-content/plugins/minisite-manager/tests/bootstrap.php
+++ b/wordpress/wp-content/plugins/minisite-manager/tests/bootstrap.php
@@ -240,6 +240,7 @@ if (! class_exists('WP_User')) {
 
 // Load WordPress function mocks
 require_once __DIR__ . '/Support/WordPressFunctions.php';
+require_once __DIR__ . '/Support/ApplicationRenderingTestStubs.php';
 
 // Mock global $wp_query
 $GLOBALS['wp_query'] = new class () {
@@ -254,8 +255,16 @@ if (! class_exists('Timber\Timber')) {
     eval('
         namespace Timber {
             class Timber {
+                public static array $locations = array();
+                public static array $renderCalls = array();
+
                 public static function render($template, $context = array())
                 {
+                    self::$renderCalls[] = array(
+                        'templates' => (array) $template,
+                        'context' => $context,
+                    );
+
                     // Output mock HTML based on context
                     $output = "<div class=\"auth-page\">";
                     if (isset($context["page_title"])) {


### PR DESCRIPTION
Implement unit and integration tests for `RewriteRegistrar` and `TimberRenderer` to achieve 90%+ test coverage.

This PR addresses MIN-39 by adding comprehensive test suites for these critical application components. It includes mocking WordPress rewrite functions and the Timber framework to enable isolated and verifiable assertions against their interactions and outputs.

---
Linear Issue: [MIN-39](https://linear.app/minisites/issue/MIN-39/feature-implement-test-coverage-for-application-folder)

<a href="https://cursor.com/background-agent?bcId=bc-e53c744f-196d-4f19-8f05-702724fa39fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e53c744f-196d-4f19-8f05-702724fa39fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

